### PR TITLE
Revert "config: Changes for libfmjni bp conversion"

### DIFF
--- a/build/soong/Android.bp
+++ b/build/soong/Android.bp
@@ -526,23 +526,6 @@ qti_vibrator_hal {
 }
 
 soong_config_module_type {
-    name: "qcom_libfmjni",
-    module_type: "cc_defaults",
-    config_namespace: "flareQcomVars",
-    bool_variables: ["no_fm_firmware"],
-    properties: ["cflags"],
-}
-
-qcom_libfmjni {
-    name: "qcom_libfmjni_defaults",
-    soong_config_variables: {
-        no_fm_firmware: {
-            cflags: ["-DQCOM_NO_FM_FIRMWARE"],
-        },
-    },
-}
-
-soong_config_module_type {
     name: "uses_legacy_fd_fbdev",
     module_type: "cc_defaults",
     config_namespace: "flareGlobalVars",

--- a/config/BoardConfigSoong.mk
+++ b/config/BoardConfigSoong.mk
@@ -73,7 +73,6 @@ SOONG_CONFIG_flareNvidiaVars += \
 
 SOONG_CONFIG_NAMESPACES += flareQcomVars
 SOONG_CONFIG_flareQcomVars += \
-    no_fm_firmware \
     qti_vibrator_effect_lib \
     qti_vibrator_use_effect_stream \
     supports_extended_compress_format \
@@ -93,7 +92,6 @@ SOONG_CONFIG_flareGlobalVars_gralloc_handle_has_reserved_size := $(TARGET_GRALLO
 SOONG_CONFIG_flareGlobalVars_gralloc_handle_has_ubwcp_format := $(TARGET_GRALLOC_HANDLE_HAS_UBWCP_FORMAT)
 SOONG_CONFIG_flareGlobalVars_uses_egl_display_array := $(TARGET_USES_EGL_DISPLAY_ARRAY)
 SOONG_CONFIG_flareNvidiaVars_uses_nvidia_enhancements := $(NV_ANDROID_FRAMEWORK_ENHANCEMENTS)
-SOONG_CONFIG_flareQcomVars_no_fm_firmware := $(TARGET_QCOM_NO_FM_FIRMWARE)
 SOONG_CONFIG_flareQcomVars_qti_vibrator_use_effect_stream := $(TARGET_QTI_VIBRATOR_USE_EFFECT_STREAM)
 SOONG_CONFIG_flareQcomVars_supports_extended_compress_format := $(AUDIO_FEATURE_ENABLED_EXTENDED_COMPRESS_FORMAT)
 SOONG_CONFIG_flareQcomVars_uses_pre_uplink_features_netmgrd := $(TARGET_USES_PRE_UPLINK_FEATURES_NETMGRD)
@@ -163,18 +161,3 @@ else
 SOONG_CONFIG_flareQcomVars_qcom_display_headers_namespace := $(QCOM_SOONG_NAMESPACE)/display
 endif
 SOONG_CONFIG_flareQcomVars_qti_vibrator_effect_lib := $(TARGET_QTI_VIBRATOR_EFFECT_LIB)
-
-# libfmjni
-ifeq ($(BOARD_HAVE_QCOM_FM),true)
-    PRODUCT_SOONG_NAMESPACES += \
-        vendor/qcom/opensource/libfmjni
-else ifeq ($(BOARD_HAVE_BCM_FM),true)
-    PRODUCT_SOONG_NAMESPACES += \
-        hardware/broadcom/fm
-else ifeq ($(BOARD_HAVE_SLSI_FM),true)
-    PRODUCT_SOONG_NAMESPACES += \
-        hardware/samsung_slsi/fm
-else ifneq ($(BOARD_HAVE_MTK_FM),true)
-    PRODUCT_SOONG_NAMESPACES += \
-        packages/apps/FMRadio/jni/fmr
-endif


### PR DESCRIPTION
This reverts commit d6777fa812d257b276985889a33f2fb5d41a577b. Reason for revert: The soong namespaces can be removed after reworking libfmjni to use select() with filegroups and header libs for qcom/slsi. Broadcom is not used in any recent shipping device and mtk can continue using prebuilt for now.

Change-Id: I078b321c7c55c3d7e5cd97e2664208c3d44f513a